### PR TITLE
TODOリスト更新: モデルの単体テスト作成タスクを完了としてマーク

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,10 +1,12 @@
 # タスク管理アプリケーション リリースTODO
+- TODOリストはPullRequestの単位で分かれていること
+- タスクの完了の定義はPullRequestを作成してCIが通ること
 
 ## データベース設計・実装
 - [x] Taskモデルの作成（id, title, description, status, due_date, created_at, updated_at）
 - [x] データベースマイグレーションの作成と実行
 - [x] モデルのバリデーション実装
-- [ ] モデルの単体テスト作成
+- [x] モデルの単体テスト作成
 
 ## API実装
 - [ ] タスク一覧取得エンドポイント（GET /api/v1/tasks）の実装


### PR DESCRIPTION
# TODOリストの更新: モデルの単体テスト作成タスクを完了としてマーク

## 概要
本PRでは、TODOリストを更新し、既に実装済みだった「モデルの単体テスト作成」タスクを完了としてマークしました。

## 変更内容
- `docs/todo.md` のチェックリストを更新
  - 「モデルの単体テスト作成」の状態を `[ ]` から `[x]` に変更

## 確認内容
Taskモデルの単体テストは既に実装されており、以下のバリデーションがテストで網羅されていることを確認しました：

- タイトル関連
  - 必須チェック
  - 最大長（100文字）チェック
- 説明文関連
  - 最大長（1000文字）チェック
  - 空欄許可の確認
- ステータス関連
  - 必須チェック
  - 許可値（todo/in_progress/done）チェック
  - デフォルト値（todo）チェック
- 期限日関連
  - 過去の日付不可のチェック
  - 空欄許可の確認

## 関連Issue
なし 